### PR TITLE
Constituent PR Test Fixes

### DIFF
--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -168,7 +168,7 @@
   type = integer
   intent = in
 [ rho ]
-  standard_name = density_of_dry_air
+  standard_name = dry_air_density
   long_name = dry air density
   units = kg m-3
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -168,7 +168,7 @@
   type = integer
   intent = in
 [ rho ]
-  standard_name = density_of_dry_air_at_stp
+  standard_name = density_of_dry_air
   long_name = dry air density
   units = kg m-3
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -134,7 +134,7 @@
   type = real | kind = kind_phys
   intent = inout
 [ qr ]
-  standard_name = rain_mixing_ratio_wrt_dry_air
+  standard_name = rain_water_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   advected = true
   units = kg kg-1

--- a/suite_held_suarez_1994.xml
+++ b/suite_held_suarez_1994.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="held_suarez" version="1.0">
+<suite name="held_suarez_1994" version="1.0">
   <group name="physics">
     <scheme>held_suarez_1994</scheme>
     <scheme>apply_tendency_of_x_wind</scheme>

--- a/suite_kessler.xml
+++ b/suite_kessler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="kessler_cam" version="1.0">
+<suite name="kessler" version="1.0">
   <group name="physics">
     <scheme>calc_exner</scheme>
     <scheme>temp_to_potential_temp</scheme>

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -108,7 +108,7 @@
   kind = kind_phys
   intent = in
 [ zvir ]
-  standard_name = composition_dependent_ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
+  standard_name = composition_dependent_ratio_of_water_vapor_to_dry_air_gas_constants_minus_one
   units = -1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -187,7 +187,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rho ]
-   standard_name = density_of_dry_air
+   standard_name = dry_air_density
    long_name = dry air density
    units = kg m-3
    dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -187,7 +187,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rho ]
-   standard_name = density_of_dry_air_at_stp
+   standard_name = density_of_dry_air
    long_name = dry air density
    units = kg m-3
    dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -379,8 +379,8 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_total_mass
-  long_name = Mass mixing ratio of cloud liquid water / total mass
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
+  long_name = Mass mixing ratio of cloud liquid water / moist_air
   advected = True
   type = real | kind = kind_phys
   units = kg kg-1
@@ -441,15 +441,15 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_mixing_ratio_wrt_total_mass
-  long_name = Mass mixing ratio of rain / total mass
+  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  long_name = Mass mixing ratio of rain / moist air
   advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr_dry ]
-  standard_name = rain_mixing_ratio_wrt_dry_air
+  standard_name = rain_water_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   type = real | kind = kind_phys
   units = kg kg-1
@@ -570,8 +570,8 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_total_mass
-  long_name = Mass mixing ratio of cloud liquid water / total mass
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
+  long_name = Mass mixing ratio of cloud liquid water / moist air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -624,15 +624,15 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr_dry ]
-  standard_name = rain_mixing_ratio_wrt_dry_air
+  standard_name = rain_water_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_mixing_ratio_wrt_total_mass
-  long_name = Mass mixing ratio of rain / total mass
+  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  long_name = Mass mixing ratio of rain / moist_air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)


### PR DESCRIPTION
Contains code changes and standard name updates found while testing this branch with CAMDEN.

In particular I believe several quantities should be `wrt_moist_air` instead of `wrt_total_mass` as it looks like currently the CAMDEN (CAM) pressure levels seen by the physics and used to convert between wet and dyr mixing ratios only include water vapor, and no other hydrometeor constituents.  

I also updated `rain` to `rain_water`, as that is how it was listed in CAMDEN (and it seemed like it was better to add more information than less in the standard name).

Finally, once this PR is merged then I'll be happy to let NCAR#52 get merged as well. 